### PR TITLE
Speedup

### DIFF
--- a/examples/protonect/src/cpu_depth_packet_processor.cpp
+++ b/examples/protonect/src/cpu_depth_packet_processor.cpp
@@ -182,19 +182,19 @@ public:
           uint16_t r9  = *(raw+9);
           uint16_t r10 = *(raw+10);
 
-          frame[ 0] = lut11to16[ ((r0>> 0) | (r1<<16)) & baseMask ];
+          frame[ 0] = lut11to16[ ((r0>> 0)           ) & baseMask ];
           frame[ 4] = lut11to16[ ((r0>>11) | (r1<< 5)) & baseMask ];
           frame[ 8] = lut11to16[ ((r1>> 6) | (r2<<10)) & baseMask ];
-          frame[12] = lut11to16[ ((r2>> 1) | (r3<<15)) & baseMask ];
+          frame[12] = lut11to16[ ((r2>> 1)           ) & baseMask ];
           frame[16] = lut11to16[ ((r2>>12) | (r3<< 4)) & baseMask ];
           frame[20] = lut11to16[ ((r3>> 7) | (r4<< 9)) & baseMask ];
-          frame[24] = lut11to16[ ((r4>> 2) | (r5<<14)) & baseMask ];
+          frame[24] = lut11to16[ ((r4>> 2)           ) & baseMask ];
           frame[28] = lut11to16[ ((r4>>13) | (r5<< 3)) & baseMask ];
           frame[32] = lut11to16[ ((r5>> 8) | (r6<< 8)) & baseMask ];
-          frame[36] = lut11to16[ ((r6>> 3) | (r7<<13)) & baseMask ];
+          frame[36] = lut11to16[ ((r6>> 3)           ) & baseMask ];
           frame[40] = lut11to16[ ((r6>>14) | (r7<< 2)) & baseMask ];
           frame[44] = lut11to16[ ((r7>> 9) | (r8<< 7)) & baseMask ];
-          frame[48] = lut11to16[ ((r8>> 4) | (r9<<12)) & baseMask ];
+          frame[48] = lut11to16[ ((r8>> 4)           ) & baseMask ];
           frame[52] = lut11to16[ ((r8>>15) | (r9<< 1)) & baseMask ];
           frame[56] = lut11to16[ ((r9>>10) | (r10<<6)) & baseMask ];
           frame[60] = lut11to16[ ((r10>>5)           ) & baseMask ];
@@ -206,6 +206,7 @@ public:
         frame += 64-4;   // advance frame pointer to the start of next 64 pixel block
         raw -= (352-11); // reset raw data pointer into the first "stripe"
       }
+      raw += 264;
     }
   }
 

--- a/examples/protonect/src/cpu_depth_packet_processor.cpp
+++ b/examples/protonect/src/cpu_depth_packet_processor.cpp
@@ -315,16 +315,18 @@ public:
   void processPixelStage1(int x, int y, unsigned char* data, float *m0_out, float *m1_out, float *m2_out)
   {
     int32_t m0_raw[3], m1_raw[3], m2_raw[3];
+    const int delta = 512*424;
+    int offset = (y < 212 ? y + 212 : 423 - y) * 512 + x;
 
-    m0_raw[0] = decodePixelMeasurement(data, 0, x, y);
-    m0_raw[1] = decodePixelMeasurement(data, 1, x, y);
-    m0_raw[2] = decodePixelMeasurement(data, 2, x, y);
-    m1_raw[0] = decodePixelMeasurement(data, 3, x, y);
-    m1_raw[1] = decodePixelMeasurement(data, 4, x, y);
-    m1_raw[2] = decodePixelMeasurement(data, 5, x, y);
-    m2_raw[0] = decodePixelMeasurement(data, 6, x, y);
-    m2_raw[1] = decodePixelMeasurement(data, 7, x, y);
-    m2_raw[2] = decodePixelMeasurement(data, 8, x, y);
+    m0_raw[0] = unpacked[offset]; offset += delta;
+    m0_raw[1] = unpacked[offset]; offset += delta;
+    m0_raw[2] = unpacked[offset]; offset += delta;
+    m1_raw[0] = unpacked[offset]; offset += delta;
+    m1_raw[1] = unpacked[offset]; offset += delta;
+    m1_raw[2] = unpacked[offset]; offset += delta;
+    m2_raw[0] = unpacked[offset]; offset += delta;
+    m2_raw[1] = unpacked[offset]; offset += delta;
+    m2_raw[2] = unpacked[offset]; offset += delta;
 
     processMeasurementTriple(p0_table0, ab_multiplier_per_frq0, x, y, m0_raw, m0_out);
     processMeasurementTriple(p0_table1, ab_multiplier_per_frq1, x, y, m1_raw, m1_out);

--- a/examples/protonect/src/cpu_depth_packet_processor.cpp
+++ b/examples/protonect/src/cpu_depth_packet_processor.cpp
@@ -643,7 +643,7 @@ void CpuDepthPacketProcessor::process(const DepthPacket &packet)
 
   float *m_ptr = m.ptr<float>();
 
-  impl_->convert_packed11_to_16bit((uint16_t*)(packet->buffer),512*424*10);
+  impl_->convert_packed11_to_16bit((uint16_t*)(packet.buffer),512*424*10);
 
   for(int y = 0; y < 424; ++y)
     for(int x = 0; x < 512; ++x, m_ptr += 9)

--- a/examples/protonect/src/cpu_depth_packet_processor.cpp
+++ b/examples/protonect/src/cpu_depth_packet_processor.cpp
@@ -79,6 +79,7 @@ public:
   float individual_ab_threshold, ab_threshold, ab_confidence_slope, ab_confidence_offset;
   float min_dealias_confidence, max_dealias_confidence;
   int16_t lut11to16[2048];
+  int16_t unpacked[512*424*10];
 
   float joint_bilateral_ab_threshold;
   float joint_bilateral_exp;
@@ -157,8 +158,9 @@ public:
   }
 
   // Loop-unrolled version of the 11-to-16 bit unpacker (with table lookup). n must be a multiple of 8.
-  void convert_packed11_to_16bit(uint8_t *raw, uint16_t *frame, int n)
+  void convert_packed11_to_16bit(uint8_t *raw, int n)
   {
+    int16_t* frame = unpacked;
     uint16_t baseMask = (1 << 11) - 1;
     while(n >= 8)
     {
@@ -619,6 +621,8 @@ void CpuDepthPacketProcessor::process(const DepthPacket &packet)
   cv::Mat m = cv::Mat::zeros(424, 512, CV_32FC(9)), m_filtered = cv::Mat::zeros(424, 512, CV_32FC(9));
 
   float *m_ptr = m.ptr<float>();
+
+  impl_->convert_packed11_to_16bit(packet->buffer,512*424*10);
 
   for(int y = 0; y < 424; ++y)
     for(int x = 0; x < 512; ++x, m_ptr += 9)

--- a/examples/protonect/src/cpu_depth_packet_processor.cpp
+++ b/examples/protonect/src/cpu_depth_packet_processor.cpp
@@ -157,37 +157,55 @@ public:
     }
   }
 
-  // Loop-unrolled version of the 11-to-16 bit unpacker (with table lookup). n must be a multiple of 8.
-  void convert_packed11_to_16bit(uint8_t *raw, int n)
+  // optimized version of the 11-to-16 bit unpacker. pixel count (n) must be a multiple of 512
+  void convert_packed11_to_16bit(uint16_t *raw, int n)
   {
     int16_t* frame = unpacked;
-    uint16_t baseMask = (1 << 11) - 1;
-    while(n >= 8)
+    const uint16_t baseMask = (1 << 11) - 1;
+    while(n >= 512)
     {
-      uint8_t r0  = *(raw+0);
-      uint8_t r1  = *(raw+1);
-      uint8_t r2  = *(raw+2);
-      uint8_t r3  = *(raw+3);
-      uint8_t r4  = *(raw+4);
-      uint8_t r5  = *(raw+5);
-      uint8_t r6  = *(raw+6);
-      uint8_t r7  = *(raw+7);
-      uint8_t r8  = *(raw+8);
-      uint8_t r9  = *(raw+9);
-      uint8_t r10 = *(raw+10);
+      // this loop completes one pixel row (8 blocks * 64 pixels = 512 pixels)
+      for (int k = 0; k < 8; k++)
+      {
+        // this loop converts & deinterlaces one contiguous block of 64 pixels
+        for (int i = 0; i < 4; i++)
+        {
+          uint16_t r0  = *(raw+0);
+          uint16_t r1  = *(raw+1);
+          uint16_t r2  = *(raw+2);
+          uint16_t r3  = *(raw+3);
+          uint16_t r4  = *(raw+4);
+          uint16_t r5  = *(raw+5);
+          uint16_t r6  = *(raw+6);
+          uint16_t r7  = *(raw+7);
+          uint16_t r8  = *(raw+8);
+          uint16_t r9  = *(raw+9);
+          uint16_t r10 = *(raw+10);
 
-      frame[0] = lut11to16[  (r0<<3)  | (r1>>5)                        ];
-      frame[1] = lut11to16[ ((r1<<6)  | (r2>>2) )           & baseMask ];
-      frame[2] = lut11to16[ ((r2<<9)  | (r3<<1) | (r4>>7) ) & baseMask ];
-      frame[3] = lut11to16[ ((r4<<4)  | (r5>>4) )           & baseMask ];
-      frame[4] = lut11to16[ ((r5<<7)  | (r6>>1) )           & baseMask ];
-      frame[5] = lut11to16[ ((r6<<10) | (r7<<2) | (r8>>6) ) & baseMask ];
-      frame[6] = lut11to16[ ((r8<<5)  | (r9>>3) )           & baseMask ];
-      frame[7] = lut11to16[ ((r9<<8)  | (r10)   )           & baseMask ];
+          frame[ 0] = lut11to16[ ((r0>> 0) | (r1<<16)) & baseMask ];
+          frame[ 4] = lut11to16[ ((r0>>11) | (r1<< 5)) & baseMask ];
+          frame[ 8] = lut11to16[ ((r1>> 6) | (r2<<10)) & baseMask ];
+          frame[12] = lut11to16[ ((r2>> 1) | (r3<<15)) & baseMask ];
+          frame[16] = lut11to16[ ((r2>>12) | (r3<< 4)) & baseMask ];
+          frame[20] = lut11to16[ ((r3>> 7) | (r4<< 9)) & baseMask ];
+          frame[24] = lut11to16[ ((r4>> 2) | (r5<<14)) & baseMask ];
+          frame[28] = lut11to16[ ((r4>>13) | (r5<< 3)) & baseMask ];
+          frame[32] = lut11to16[ ((r5>> 8) | (r6<< 8)) & baseMask ];
+          frame[36] = lut11to16[ ((r6>> 3) | (r7<<13)) & baseMask ];
+          frame[40] = lut11to16[ ((r6>>14) | (r7<< 2)) & baseMask ];
+          frame[44] = lut11to16[ ((r7>> 9) | (r8<< 7)) & baseMask ];
+          frame[48] = lut11to16[ ((r8>> 4) | (r9<<12)) & baseMask ];
+          frame[52] = lut11to16[ ((r8>>15) | (r9<< 1)) & baseMask ];
+          frame[56] = lut11to16[ ((r9>>10) | (r10<<6)) & baseMask ];
+          frame[60] = lut11to16[ ((r10>>5)           ) & baseMask ];
 
-      n -= 8;
-      raw += 11;
-      frame += 8;
+          n -= 16;
+          raw += 88;
+          frame++;
+        }
+        frame += 64-4;   // advance frame pointer to the start of next 64 pixel block
+        raw -= (352-11); // reset raw data pointer into the first "stripe"
+      }
     }
   }
 
@@ -624,7 +642,7 @@ void CpuDepthPacketProcessor::process(const DepthPacket &packet)
 
   float *m_ptr = m.ptr<float>();
 
-  impl_->convert_packed11_to_16bit(packet->buffer,512*424*10);
+  impl_->convert_packed11_to_16bit((uint16_t*)(packet->buffer),512*424*10);
 
   for(int y = 0; y < 424; ++y)
     for(int x = 0; x < 512; ++x, m_ptr += 9)

--- a/examples/protonect/src/cpu_depth_packet_processor.cpp
+++ b/examples/protonect/src/cpu_depth_packet_processor.cpp
@@ -156,6 +156,39 @@ public:
     }
   }
 
+  // Loop-unrolled version of the 11-to-16 bit unpacker (with table lookup). n must be a multiple of 8.
+  void convert_packed11_to_16bit(uint8_t *raw, uint16_t *frame, int n)
+  {
+    uint16_t baseMask = (1 << 11) - 1;
+    while(n >= 8)
+    {
+      uint8_t r0  = *(raw+0);
+      uint8_t r1  = *(raw+1);
+      uint8_t r2  = *(raw+2);
+      uint8_t r3  = *(raw+3);
+      uint8_t r4  = *(raw+4);
+      uint8_t r5  = *(raw+5);
+      uint8_t r6  = *(raw+6);
+      uint8_t r7  = *(raw+7);
+      uint8_t r8  = *(raw+8);
+      uint8_t r9  = *(raw+9);
+      uint8_t r10 = *(raw+10);
+
+      frame[0] = lut11to16[  (r0<<3)  | (r1>>5)                        ];
+      frame[1] = lut11to16[ ((r1<<6)  | (r2>>2) )           & baseMask ];
+      frame[2] = lut11to16[ ((r2<<9)  | (r3<<1) | (r4>>7) ) & baseMask ];
+      frame[3] = lut11to16[ ((r4<<4)  | (r5>>4) )           & baseMask ];
+      frame[4] = lut11to16[ ((r5<<7)  | (r6>>1) )           & baseMask ];
+      frame[5] = lut11to16[ ((r6<<10) | (r7<<2) | (r8>>6) ) & baseMask ];
+      frame[6] = lut11to16[ ((r8<<5)  | (r9>>3) )           & baseMask ];
+      frame[7] = lut11to16[ ((r9<<8)  | (r10)   )           & baseMask ];
+
+      n -= 8;
+      raw += 11;
+      frame += 8;
+    }
+  }
+
   int32_t decodePixelMeasurement(unsigned char* data, int sub, int x, int y)
   {
     // 298496 = 512 * 424 * 11 / 8 = number of bytes per sub image


### PR DESCRIPTION
Hi again, this one is more of a starting point for discussion: 

I've done some profiling, and it looked like decodePixelMeasurement was consuming a significant amount of CPU time (~ 15%). To optimize that, I created a loop-based version from the original libfreenect1 code which unpacks all 10 subframes at once instead of pixel-by-pixel. However, the resulting speedup appears to be around ~ 2% at best, so it's not even clear if there is any real effect at all or just measurement noise...

Thoughts?

Florian
