### PR TITLE
replace per-pixel trig calculations with table lookups

### DIFF
--- a/examples/protonect/src/cpu_depth_packet_processor.cpp
+++ b/examples/protonect/src/cpu_depth_packet_processor.cpp
@@ -85,13 +85,9 @@ public:
 
   float gaussian_kernel[9];
 
-  cv::Mat* sin_tables0[3];
-  cv::Mat* sin_tables1[3];
-  cv::Mat* sin_tables2[3];
-
-  cv::Mat* cos_tables0[3];
-  cv::Mat* cos_tables1[3];
-  cv::Mat* cos_tables2[3];
+  float trig_table0[512*424][6];
+  float trig_table1[512*424][6];
+  float trig_table2[512*424][6];
 
   double timing_acc;
   double timing_acc_n;
@@ -136,17 +132,6 @@ public:
 
     newIrFrame();
     newDepthFrame();
-
-    for (int i = 0; i < 3; i++)
-    {
-      sin_tables0[i] = new cv::Mat(424,512,CV_32FC1);
-      sin_tables1[i] = new cv::Mat(424,512,CV_32FC1);
-      sin_tables2[i] = new cv::Mat(424,512,CV_32FC1);
-
-      cos_tables0[i] = new cv::Mat(424,512,CV_32FC1);
-      cos_tables1[i] = new cv::Mat(424,512,CV_32FC1);
-      cos_tables2[i] = new cv::Mat(424,512,CV_32FC1);
-    }
 
     timing_acc = 0.0;
     timing_acc_n = 0.0;
@@ -247,7 +232,7 @@ public:
     return lut11to16[((i1 | i2) & 2047)];
   }
 
-  void fill_trig_tables(cv::Mat& p0table, cv::Mat* cos_table[], cv::Mat* sin_table[])
+  void fill_trig_tables(cv::Mat& p0table, float trig_table[512*424][6])
   {
     for (int i = 0; i < 512*424; i++)
     {
@@ -257,25 +242,26 @@ public:
       float tmp1 = p0 + phase_in_rad1;
       float tmp2 = p0 + phase_in_rad2;
 
-      cos_table[0]->at<float>(i) = std::cos(tmp0);
-      cos_table[1]->at<float>(i) = std::cos(tmp1);
-      cos_table[2]->at<float>(i) = std::cos(tmp2);
+      trig_table[i][0] = std::cos(tmp0);
+      trig_table[i][1] = std::cos(tmp1);
+      trig_table[i][2] = std::cos(tmp2);
 
-      sin_table[0]->at<float>(i) = std::sin(-tmp0);
-      sin_table[1]->at<float>(i) = std::sin(-tmp1);
-      sin_table[2]->at<float>(i) = std::sin(-tmp2);
+      trig_table[i][3] = std::sin(-tmp0);
+      trig_table[i][4] = std::sin(-tmp1);
+      trig_table[i][5] = std::sin(-tmp2);
     }
   }
 
-  void processMeasurementTriple(cv::Mat* cos_table[], cv::Mat* sin_table[], float abMultiplierPerFrq, int x, int y, const int32_t* m, float* m_out)
+  void processMeasurementTriple(float trig_table[512*424][6], float abMultiplierPerFrq, int x, int y, const int32_t* m, float* m_out)
   {
-    float cos_tmp0 = cos_table[0]->at<float>(y,x);
-    float cos_tmp1 = cos_table[1]->at<float>(y,x);
-    float cos_tmp2 = cos_table[2]->at<float>(y,x);
+    int offset = y * 512 + x;
+    float cos_tmp0 = trig_table[offset][0];
+    float cos_tmp1 = trig_table[offset][1];
+    float cos_tmp2 = trig_table[offset][2];
 
-    float sin_negtmp0 = sin_table[0]->at<float>(y,x);
-    float sin_negtmp1 = sin_table[1]->at<float>(y,x);
-    float sin_negtmp2 = sin_table[2]->at<float>(y,x);
+    float sin_negtmp0 = trig_table[offset][3];
+    float sin_negtmp1 = trig_table[offset][4];
+    float sin_negtmp2 = trig_table[offset][5];
 
     float zmultiplier = z_table.at<float>(y, x);
     bool cond0 = 0 < zmultiplier;
@@ -333,9 +319,9 @@ public:
     m2_raw[1] = decodePixelMeasurement(data, 7, x, y);
     m2_raw[2] = decodePixelMeasurement(data, 8, x, y);
 
-    processMeasurementTriple(cos_tables0, sin_tables0, ab_multiplier_per_frq0, x, y, m0_raw, m0_out);
-    processMeasurementTriple(cos_tables1, sin_tables1, ab_multiplier_per_frq1, x, y, m1_raw, m1_out);
-    processMeasurementTriple(cos_tables2, sin_tables2, ab_multiplier_per_frq2, x, y, m2_raw, m2_out);
+    processMeasurementTriple(trig_table0, ab_multiplier_per_frq0, x, y, m0_raw, m0_out);
+    processMeasurementTriple(trig_table1, ab_multiplier_per_frq1, x, y, m1_raw, m1_out);
+    processMeasurementTriple(trig_table2, ab_multiplier_per_frq2, x, y, m2_raw, m2_out);
   }
 
   void filterPixelStage1(int x, int y, const cv::Mat& m, float* m_out)
@@ -595,9 +581,9 @@ void CpuDepthPacketProcessor::loadP0TablesFromCommandResponse(unsigned char* buf
   cv::flip(cv::Mat(424, 512, CV_16UC1, p0table->p0table1), impl_->p0_table1, 0);
   cv::flip(cv::Mat(424, 512, CV_16UC1, p0table->p0table2), impl_->p0_table2, 0);
 
-  impl_->fill_trig_tables(impl_->p0_table0, impl_->cos_tables0, impl_->sin_tables0);
-  impl_->fill_trig_tables(impl_->p0_table1, impl_->cos_tables1, impl_->sin_tables1);
-  impl_->fill_trig_tables(impl_->p0_table2, impl_->cos_tables2, impl_->sin_tables2);
+  impl_->fill_trig_tables(impl_->p0_table0, impl_->trig_table0);
+  impl_->fill_trig_tables(impl_->p0_table1, impl_->trig_table1);
+  impl_->fill_trig_tables(impl_->p0_table2, impl_->trig_table2);
 }
 
 void CpuDepthPacketProcessor::loadXTableFromFile(const char* filename)


### PR DESCRIPTION
I've found a more worthwhile opportunity for optimization: the trig calculations in processMeasurementTriple don't actually depend on live pixel data, but just on the p0tables, so they can easily be pre-calculated as lookup tables. This saves a total of 180 trigonometry operations per output pixel and results in a speedup of just about 2 x (at least without bilinear filtering):

ir_iso_transfer: [CpuDepthPacketProcessor] avg. time: 155.165ms -> ~6.44476Hz
trig_tables:       [CpuDepthPacketProcessor] avg. time:   82.522ms -> ~12.118Hz

If enough texture units are available, this might also be useful for a GLSL-based implementation.
