### PR TITLE
Changes need to work

### DIFF
--- a/depends/install_mac.sh
+++ b/depends/install_mac.sh
@@ -23,6 +23,7 @@ cp $LIBUSBX_SOURCE_DIR/config.sub ./
 make && make install
 
 #get the missing cl.hpp from Khronos.org
-cd /System/Library/Frameworks/OpenCL.framework/Versions/A/Headers/ && sudo wget http://www.khronos.org/registry/cl/api/1.2/cl.hpp
+cd /System/Library/Frameworks/OpenCL.framework/Versions/A/Headers/ 
+[ -f cl.hpp ] || sudo wget http://www.khronos.org/registry/cl/api/1.2/cl.hpp
 
 cd $DEPENDS_DIR


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1165340/5121926/97636b76-709a-11e4-982e-3d1666dd9010.png)

For some reason if the AsyncPacketProcessor is exported, it starts generating linking erros to the tthread::mutex class. I cannot figure out why, with this quick look. But it is not necessary to export this particular class for the project to work though.

Maybe you have an idea?
